### PR TITLE
Major optimisation for non-default time regression

### DIFF
--- a/main/compute_inventory.py
+++ b/main/compute_inventory.py
@@ -64,7 +64,7 @@ def process_file(filename, inventory=True, time=DEFAULT_TIME):
 
 def compute_inventory(T, c_max, time):
 
-    if time not in database_inv_sig.keys():  # if time is not the default value
+    if time not in database_inv_sig.keys():  # if time is not in the database
         GP = estimate_inventory_with_gp_regression(time=time)
 
         def inv_T_c_local(T, c):


### PR DESCRIPTION
Fixes #16 
Instead of recomputing the callables everytime, `inv_T_c``and `sig_T_c` are stored in a dict to be fetched later on.

This is particularly usefull when the inventory at several times is needed.

For instance, the script plot_time_dependent_ITER.py takes a few seconds to run now, compared to a few minutes before...